### PR TITLE
ci(lint): parse YAML with compose_all instead of safe_load_all

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,10 @@ jobs:
               if '.git/' in path or 'node_modules/' in path: continue
               try:
                   with open(path) as f:
-                      list(yaml.safe_load_all(f))
+                      # compose_all parses syntax without constructing tags —
+                      # docker-compose 'ports: !reset []' (Compose Spec 2.20+)
+                      # is valid for Compose but unknown to safe_load_all.
+                      list(yaml.compose_all(f))
               except Exception as e:
                   print(f'::error file={path}::{e}')
                   ok = False


### PR DESCRIPTION
main 上 Lint/yaml 失败：`safe_load_all` 无法构造 docker-compose 的 `ports: !reset []`（Compose Spec 2.20+ 自定义 tag）。

改用 `yaml.compose_all` — 只做语法解析、不构造 tag，符合该步骤「轻量语法校验」的定位。已在本地用同版本 PyYAML 验证 `docker-compose.test.override.yml` 解析通过。