### PR TITLE
fix(client): clean up all flutter analyze warnings to unblock CI

### DIFF
--- a/apps/client/.gitignore
+++ b/apps/client/.gitignore
@@ -48,8 +48,13 @@ app.*.map.json
 editor-web/dist/
 editor-web/node_modules/
 # editor bundle 由 `make editor-web-build` 同步过来; 不入仓
+# （保留 .gitkeep 让目录存在, 否则 flutter analyze 报 asset_directory_does_not_exist）
 web/editor/
-assets/editor/
+assets/editor/*
+!assets/editor/assets/
+!assets/editor/.gitkeep
+assets/editor/assets/*
+!assets/editor/assets/.gitkeep
 
 # 发布产物 (CI/本机验证生成; releases.json 不进 git, 见 docs/BiuMind-Client-Build.md)
 /biumind-*.apk

--- a/apps/client/lib/app/theme/biu_tokens.dart
+++ b/apps/client/lib/app/theme/biu_tokens.dart
@@ -5,7 +5,7 @@
 //
 // 内部状态:
 //   * `_isDark`         — 由 main.dart::BiuMindApp.builder 在每次 build 同步
-//   * `_currentPalette` — 由 buildTheme() 调用前设置;读色全走当前色板
+//   * `palette`         — 由 buildTheme() 调用前设置;读色全走当前色板
 //
 // 所有 getter 标 @Deprecated,但保留运行时正确 — 老代码颜色会跟当前色板同步切。
 // 若用户切到非紫色板 (Phase 3 后),`BiuTokens.purple` 实际返回当前 brand。
@@ -23,7 +23,9 @@ class BiuTokens {
 
   // ─── 全局状态 (theme builder 同步) ────────────────────────────
   static bool _isDark = false;
-  static PaletteId _currentPalette = PaletteId.inkblueOrange;
+
+  /// 由 main.dart 在每次 build 前同步 (跟 brightness 一起)。
+  static PaletteId palette = PaletteId.inkblueOrange;
 
   /// 顶层 ThemeBinding 改这个; widget 重 build 自动用新值。
   static set brightness(Brightness b) {
@@ -33,15 +35,8 @@ class BiuTokens {
   static Brightness get brightness =>
       _isDark ? Brightness.dark : Brightness.light;
 
-  /// 由 main.dart 在每次 build 前同步 (跟 brightness 一起)。
-  static set palette(PaletteId p) {
-    _currentPalette = p;
-  }
-
-  static PaletteId get palette => _currentPalette;
-
   // ── 内部 helper ──────────────────────────────────────────────
-  static PaletteSpec get _spec => paletteSpecOf(_currentPalette);
+  static PaletteSpec get _spec => paletteSpecOf(palette);
   static NeutralTokens get _n =>
       NeutralTokens.forBrightness(_isDark ? Brightness.dark : Brightness.light);
   static Brightness get _b => _isDark ? Brightness.dark : Brightness.light;

--- a/apps/client/lib/app/theme/effects.dart
+++ b/apps/client/lib/app/theme/effects.dart
@@ -167,7 +167,7 @@ const List<Shadow> bannerTextShadow = [
 ///     children: [
 ///       Positioned.fill(child: DecoratedBox(decoration: main)),
 ///       Positioned.fill(child: DecoratedBox(decoration: scrim)),
-///       <content>
+///       `<content>`
 ///     ],
 ///   )
 ({BoxDecoration main, BoxDecoration scrim}) bannerLayers(

--- a/apps/client/lib/core/collab/collab_presence.dart
+++ b/apps/client/lib/core/collab/collab_presence.dart
@@ -43,7 +43,7 @@ class RemoteCursor {
 }
 
 abstract interface class CollabPresence {
-  /// Watch remote cursors on a resource (e.g. wiki://page/<id>).
+  /// Watch remote cursors on a resource (e.g. `wiki://page/<id>`).
   Stream<List<RemoteCursor>> watch(String resourceUri);
 
   /// Push local cursor update; throttled by caller (recommend 200ms).

--- a/apps/client/lib/core/editor/editor_bridge_protocol.dart
+++ b/apps/client/lib/core/editor/editor_bridge_protocol.dart
@@ -111,7 +111,7 @@ BridgeMessage setOptionsMessage({BridgeTheme? theme, bool? readOnly}) {
     type: 'setOptions',
     payload: {
       if (theme != null) 'theme': theme.wire,
-      if (readOnly != null) 'readOnly': readOnly,
+      'readOnly': ?readOnly,
     },
   );
 }
@@ -119,7 +119,7 @@ BridgeMessage setOptionsMessage({BridgeTheme? theme, bool? readOnly}) {
 BridgeMessage commandMessage(String name, {Map<String, dynamic>? args}) {
   return BridgeMessage(
     type: 'command',
-    payload: {'name': name, if (args != null) 'args': args},
+    payload: {'name': name, 'args': ?args},
   );
 }
 

--- a/apps/client/lib/core/editor/editor_native_view.dart
+++ b/apps/client/lib/core/editor/editor_native_view.dart
@@ -101,7 +101,7 @@ class _EditorNativeViewState extends State<EditorNativeView> {
             iframeAllowFullscreen: false,
           ),
           onWebViewCreated: _onCreated,
-          onLoadStop: (_, __) {
+          onLoadStop: (_, _) {
             // The bundle's `bridge.start()` sends `ready` itself; the
             // controller's onIncomingMessage takes care of everything
             // from there.

--- a/apps/client/lib/data/agent_plane/agent_plane_client.dart
+++ b/apps/client/lib/data/agent_plane/agent_plane_client.dart
@@ -99,23 +99,23 @@ class AgentPlaneClient {
       'mode': mode,
       // 用 if 而非 null-aware (?'key':val) —— 后者跟 ProgressIndicator
       // 等老 SDK 不兼容；info 级 lint 让它存在不影响 build
-      if (environmentId != null) 'environment_id': environmentId,
-      if (threadId != null) 'thread_id': threadId,
-      if (model != null) 'model': model,
-      if (providerId != null) 'provider_id': providerId,
-      if (systemPrompt != null) 'system_prompt': systemPrompt,
-      if (prompt != null) 'prompt': prompt,
-      if (poolTag != null) 'pool_tag': poolTag,
-      if (workdir != null) 'workdir': workdir,
-      if (runtimeEnvMode != null) 'runtime_env_mode': runtimeEnvMode,
-      if (backend != null) 'backend': backend,
+      'environment_id': ?environmentId,
+      'thread_id': ?threadId,
+      'model': ?model,
+      'provider_id': ?providerId,
+      'system_prompt': ?systemPrompt,
+      'prompt': ?prompt,
+      'pool_tag': ?poolTag,
+      'workdir': ?workdir,
+      'runtime_env_mode': ?runtimeEnvMode,
+      'backend': ?backend,
       if (images != null && images.isNotEmpty)
         'images': images.map((i) => i.toJson()).toList(),
-      if (userMessageId != null) 'user_message_id': userMessageId,
-      if (assistantMessageId != null) 'assistant_message_id': assistantMessageId,
-      if (clientSideRecordId != null) 'client_side_record_id': clientSideRecordId,
-      if (clientSideBaseUrl != null) 'client_side_base_url': clientSideBaseUrl,
-      if (clientSideProtocol != null) 'client_side_protocol': clientSideProtocol,
+      'user_message_id': ?userMessageId,
+      'assistant_message_id': ?assistantMessageId,
+      'client_side_record_id': ?clientSideRecordId,
+      'client_side_base_url': ?clientSideBaseUrl,
+      'client_side_protocol': ?clientSideProtocol,
     };
     final sw = Stopwatch()..start();
     debugPrint('[agent_plane] createSession mode=$mode env=$environmentId'

--- a/apps/client/lib/data/api/biu_client.dart
+++ b/apps/client/lib/data/api/biu_client.dart
@@ -333,7 +333,7 @@ class BiuClient {
 /// 测试可以传内存 fake。frames 是 broadcast / single-subscribe 都行
 /// （BiuClient 自己只 listen 一次）。
 abstract class BiuTransport {
-  /// 下行帧 stream。每条 element 是 server push 的原始 String / List<int>。
+  /// 下行帧 stream。每条 element 是 server push 的原始 String / `List<int>`。
   /// BiuClient 只处理 String 类型；Binary 直接 drop。
   Stream<dynamic> get frames;
 

--- a/apps/client/lib/data/api/skill_client.dart
+++ b/apps/client/lib/data/api/skill_client.dart
@@ -103,8 +103,8 @@ class Skill {
   final SkillManifest manifest;
   final String content;
   final String contentHash;
-  /// Map<vpath, ResourceMeta> — vpath shapes:
-  ///   references/<file>  / scripts/<file>  / assets/<file>
+  /// `Map<vpath, ResourceMeta>` — vpath shapes:
+  ///   `references/<file>`  / `scripts/<file>`  / `assets/<file>`
   /// Empty for bundled / inline-only skills.
   final Map<String, SkillResource> resources;
   final List<String> paths;
@@ -112,7 +112,7 @@ class Skill {
   final String zipFileSha256;
   /// Set on staged skills proposing to replace an active row — the
   /// predecessor's id. Empty otherwise. Powers the diff hint in the
-  /// detail drawer ("基于 v<hash>") so reviewers know what changed.
+  /// detail drawer ("基于 `v<hash>`") so reviewers know what changed.
   final String updateOfId;
   final DateTime createdAt;
   final DateTime updatedAt;

--- a/apps/client/lib/data/local/db.dart
+++ b/apps/client/lib/data/local/db.dart
@@ -142,7 +142,7 @@ class NoteNotes extends Table {
   Set<Column> get primaryKey => {id};
 }
 
-/// NoteTags —— 个人标签（服务端 scope_key='personal:<uid>' 单用户，
+/// NoteTags —— 个人标签（服务端 `scope_key='personal:<uid>'` 单用户，
 /// 本地不必再存 scope）。创建幂等，flush 成功后 rekey。
 @DataClassName('LocalNoteTag')
 class NoteTags extends Table {
@@ -293,7 +293,7 @@ class SseCursors extends Table {
 /// 不持久化产物 url (cas:sha 是云端引用, 不存本地). 仅持久化 task 元数据 +
 /// outputs JSON 供重启秒回 UI.
 ///
-/// outputs_json 是 List<TaskOutput> JSON, params_json 是 Map<String, dynamic>
+/// outputs_json 是 `List<TaskOutput>` JSON, params_json 是 `Map<String, dynamic>`
 /// JSON. 状态机字段 status / progress 跟 CreationTask 一致.
 @DataClassName('LocalAigcTask')
 class AigcTasks extends Table {

--- a/apps/client/lib/features/chat/presentation/v2/message_bubble_v2.dart
+++ b/apps/client/lib/features/chat/presentation/v2/message_bubble_v2.dart
@@ -196,10 +196,13 @@ class _MessageBubbleV2State extends ConsumerState<MessageBubbleV2> {
     // R1.7: 手机长按 → bottom sheet (IM 标准, 对标微信/ChatGPT mobile;
     // popup 在触屏位置不准且小)。桌面维持 popup (定位精确)。sheet 加
     // 「复制」高频项 (footer 已有, 长按镜像方便单手)。
+    if (!context.mounted) return;
     final phone = isPhoneLayout(context);
-    final picked = phone
-        ? await _showLongPressSheet(context, m)
-        : await showMenu<String>(
+    final String? picked;
+    if (phone) {
+      picked = await _showLongPressSheet(context, m);
+    } else {
+      picked = await showMenu<String>(
             context: context,
             position: popupPositionAt(context, pos),
             items: [
@@ -245,6 +248,7 @@ class _MessageBubbleV2State extends ConsumerState<MessageBubbleV2> {
               ),
             ],
           );
+    }
     if (!mounted || picked == null) return;
     final repo = ref.read(chatControllerDepsProvider).repo;
     switch (picked) {

--- a/apps/client/lib/features/code/application/tasks_controller.dart
+++ b/apps/client/lib/features/code/application/tasks_controller.dart
@@ -413,6 +413,17 @@ class CodeTasksController extends StateNotifier<List<CodeTask>> {
     if (firstLine.length <= 50) return firstLine;
     return '${firstLine.substring(0, 47)}…';
   }
+
+  /// 删除任务 — 同步删 db + 清理 worktree (默认强删, 任务历史用户已经决定不要)。
+  Future<void> deleteTask(String taskId, {bool purgeWorktree = true}) async {
+    if (purgeWorktree) {
+      try {
+        await _workspaces.purge(taskId);
+      } catch (_) {/* worktree 已被手动删 / git 报错时忽略 */}
+    }
+    await _dao.deleteById(taskId);
+    state = state.where((t) => t.id != taskId).toList();
+  }
 }
 
 // ─── Providers ───────────────────────────────────────────
@@ -513,18 +524,6 @@ extension CodeTasksControllerActions on CodeTasksController {
   Future<void> purgeWorkspace(String taskId) async {
     await _workspaces.purge(taskId);
   }
-
-  /// 删除任务 — 同步删 db + 清理 worktree (默认强删, 任务历史用户已经决定不要)。
-  Future<void> deleteTask(String taskId, {bool purgeWorktree = true}) async {
-    if (purgeWorktree) {
-      try {
-        await _workspaces.purge(taskId);
-      } catch (_) {/* worktree 已被手动删 / git 报错时忽略 */}
-    }
-    await _dao.deleteById(taskId);
-    state = state.where((t) => t.id != taskId).toList();
-  }
-
 }
 
 /// 主区当前显示的任务 id（null = 空状态）

--- a/apps/client/lib/features/membership/data/coupons_client.dart
+++ b/apps/client/lib/features/membership/data/coupons_client.dart
@@ -22,9 +22,9 @@ class CouponsClient {
       bearerToken: getToken(),
       body: {
         'code': code,
-        if (planCode != null) 'plan_code': planCode,
-        if (amountCents != null) 'amount_cents': amountCents,
-        if (currency != null) 'currency': currency,
+        'plan_code': ?planCode,
+        'amount_cents': ?amountCents,
+        'currency': ?currency,
       },
     );
     return CouponRedeemResult.fromJson(j);

--- a/apps/client/lib/features/membership/presentation/pages/membership_center_page.dart
+++ b/apps/client/lib/features/membership/presentation/pages/membership_center_page.dart
@@ -514,14 +514,14 @@ class _CancelDialogWrapperState extends ConsumerState<_CancelDialogWrapper> {
         setState(() => _busy = true);
         try {
           await actions.cancel(immediate: immediate);
-          if (mounted) {
+          if (context.mounted) {
             Navigator.of(context).pop();
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(content: Text(immediate ? '订阅已立即取消' : '订阅将于周期末取消')),
             );
           }
         } catch (e) {
-          if (mounted) {
+          if (context.mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(content: Text('取消失败: $e')),
             );

--- a/apps/client/lib/features/membership/presentation/pages/order_history_page.dart
+++ b/apps/client/lib/features/membership/presentation/pages/order_history_page.dart
@@ -34,7 +34,7 @@ class OrderHistoryPage extends ConsumerWidget {
           return ListView.separated(
             padding: const EdgeInsets.all(16),
             itemBuilder: (ctx, i) => _OrderCard(order: orders[i]),
-            separatorBuilder: (_, __) => const SizedBox(height: 8),
+            separatorBuilder: (_, _) => const SizedBox(height: 8),
             itemCount: orders.length,
           );
         },

--- a/apps/client/lib/features/membership/presentation/widgets/cancel_confirm_dialog.dart
+++ b/apps/client/lib/features/membership/presentation/widgets/cancel_confirm_dialog.dart
@@ -38,35 +38,37 @@ class _CancelConfirmDialogState extends State<CancelConfirmDialog> {
 
     return AlertDialog(
       title: const Text('取消订阅'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            '当前方案: ${widget.subscription.plan.name}',
-            style: theme.textTheme.bodyMedium,
-          ),
-          const SizedBox(height: 12),
-          RadioListTile<bool>(
-            title: const Text('周期结束时停止'),
-            subtitle: Text('继续服务至 $endStr, 不退款'),
-            value: false,
-            groupValue: _immediate,
-            onChanged: (v) => setState(() => _immediate = v ?? false),
-          ),
-          RadioListTile<bool>(
-            title: const Text('立即停止 + 按比例退款'),
-            subtitle: const Text('剩余周期按 proration 计算退款'),
-            value: true,
-            groupValue: _immediate,
-            onChanged: (v) => setState(() => _immediate = v ?? true),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            '取消后随时可在 period_end 前点 "恢复" 撤销操作',
-            style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
-          ),
-        ],
+      content: RadioGroup<bool>(
+        groupValue: _immediate,
+        onChanged: (v) {
+          if (v != null) setState(() => _immediate = v);
+        },
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '当前方案: ${widget.subscription.plan.name}',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 12),
+            RadioListTile<bool>(
+              title: const Text('周期结束时停止'),
+              subtitle: Text('继续服务至 $endStr, 不退款'),
+              value: false,
+            ),
+            RadioListTile<bool>(
+              title: const Text('立即停止 + 按比例退款'),
+              subtitle: const Text('剩余周期按 proration 计算退款'),
+              value: true,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '取消后随时可在 period_end 前点 "恢复" 撤销操作',
+              style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
+            ),
+          ],
+        ),
       ),
       actions: [
         TextButton(

--- a/apps/client/lib/features/membership/presentation/widgets/payment_method_selector.dart
+++ b/apps/client/lib/features/membership/presentation/widgets/payment_method_selector.dart
@@ -79,30 +79,32 @@ class _PaymentMethodSelectorState extends State<PaymentMethodSelector> {
         ),
     ];
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text('选择支付方式', style: theme.textTheme.titleMedium),
-        const SizedBox(height: 8),
-        ...options.map(
-          (o) => RadioListTile<PaymentProvider>(
-            title: Row(
-              children: [
-                Icon(o.icon, size: 18),
-                const SizedBox(width: 8),
-                Text(o.label),
-              ],
+    return RadioGroup<PaymentProvider>(
+      groupValue: _selected,
+      onChanged: (v) {
+        if (v == null) return;
+        setState(() => _selected = v);
+        widget.onSelected(v);
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('选择支付方式', style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          ...options.map(
+            (o) => RadioListTile<PaymentProvider>(
+              title: Row(
+                children: [
+                  Icon(o.icon, size: 18),
+                  const SizedBox(width: 8),
+                  Text(o.label),
+                ],
+              ),
+              value: o.provider,
             ),
-            value: o.provider,
-            groupValue: _selected,
-            onChanged: (v) {
-              if (v == null) return;
-              setState(() => _selected = v);
-              widget.onSelected(v);
-            },
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/apps/client/lib/features/skills/presentation/skill_detail_page.dart
+++ b/apps/client/lib/features/skills/presentation/skill_detail_page.dart
@@ -405,7 +405,7 @@ class _OverviewTab extends StatelessWidget {
   /// "—" or hidden once stats arrive.
   final SkillActivationsResult? activations;
   /// When skill.updateOfId points at an existing row, this is the
-  /// predecessor's resolved Skill — drives the "基于 v<hash> · diff"
+  /// predecessor's resolved Skill — drives the "基于 `v<hash>` · diff"
   /// hint above the action buttons.
   final Skill? predecessor;
   final VoidCallback onApprove;

--- a/apps/client/lib/features/wiki/application/sync_provider.dart
+++ b/apps/client/lib/features/wiki/application/sync_provider.dart
@@ -5,7 +5,7 @@
 /// 接通 events_outbox listener 后会真正推 catchup/live 帧）。
 ///
 /// 任何模块都可以 `ref.watch(wikiSyncEventsProvider(projectId))` 监听
-/// 实时事件流（每个事件一个 Map<Object?, Object?>，schema 与 brain.events
+/// 实时事件流（每个事件一个 `Map<Object?, Object?>`，schema 与 brain.events
 /// 表 row 投影一致）。
 library;
 

--- a/apps/client/lib/features/wiki/data/sync_ws_client.dart
+++ b/apps/client/lib/features/wiki/data/sync_ws_client.dart
@@ -4,7 +4,7 @@
 /// 端点协议格式：
 ///
 ///   - {type: "catchup", events: [...]}
-///   - {type: "ready", since: <event_id>}
+///   - {type: "ready", since: `<event_id>`}
 ///   - {type: "live", event: {...}}
 ///   - {type: "ping"}
 ///   - {type: "error", reason: "..."}

--- a/apps/client/lib/features/wiki/presentation/connectors/import_dialog.dart
+++ b/apps/client/lib/features/wiki/presentation/connectors/import_dialog.dart
@@ -244,7 +244,7 @@ class _DialogState extends ConsumerState<_Dialog> {
       metadata: {
         'project_id': widget.projectId,
         'rel_path': filename,
-        if (externalId != null) 'external_id': externalId,
+        'external_id': ?externalId,
       },
       onProgress: (sent, total) =>
           _updateItem(index, sent: sent, total: total),

--- a/apps/client/test/app/router_public_route_test.dart
+++ b/apps/client/test/app/router_public_route_test.dart
@@ -5,8 +5,6 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart' show NoTransitionPage;
 import 'package:biumind/app/router.dart';

--- a/apps/client/test/app/theme/wcag_contrast_test.dart
+++ b/apps/client/test/app/theme/wcag_contrast_test.dart
@@ -21,7 +21,6 @@ import 'dart:math' as math;
 import 'dart:ui' show Color;
 
 import 'package:flutter/material.dart' show Brightness;
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/app/theme/palettes.dart';

--- a/apps/client/test/core/ai_surface_test.dart
+++ b/apps/client/test/core/ai_surface_test.dart
@@ -1,5 +1,4 @@
 import 'package:biumind/core/ai/ai_surface.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _ScriptedBackend extends AiSurfaceBackend {

--- a/apps/client/test/core/collab_presence_test.dart
+++ b/apps/client/test/core/collab_presence_test.dart
@@ -1,7 +1,5 @@
 import 'package:biumind/core/collab/collab_presence.dart';
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/core/command_registry_test.dart
+++ b/apps/client/test/core/command_registry_test.dart
@@ -1,5 +1,4 @@
 import 'package:biumind/core/commands/command_registry.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/core/layout/form_factor_test.dart
+++ b/apps/client/test/core/layout/form_factor_test.dart
@@ -2,8 +2,6 @@
 // 方案: docs/BiuMind-Mobile-Adaptation-Plan.md §4.1/§4.2
 
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/core/layout/form_factor.dart';

--- a/apps/client/test/core/layout/phone_tab_bar_test.dart
+++ b/apps/client/test/core/layout/phone_tab_bar_test.dart
@@ -81,7 +81,7 @@ void main() {
     final router = GoRouter(routes: [
       GoRoute(
         path: '/',
-        builder: (_, __) => const Scaffold(body: PhoneTabBar()),
+        builder: (_, _) => const Scaffold(body: PhoneTabBar()),
       ),
     ]);
     await tester.pumpWidget(MaterialApp.router(

--- a/apps/client/test/core/os_integration_test.dart
+++ b/apps/client/test/core/os_integration_test.dart
@@ -1,5 +1,4 @@
 import 'package:biumind/core/osintegration/os_integration.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/core/platform_caps_test.dart
+++ b/apps/client/test/core/platform_caps_test.dart
@@ -3,7 +3,6 @@
 // shape + that detection doesn't throw.
 
 import 'package:biumind/core/platform/platform_caps.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/core/ui/adaptive_dialog_test.dart
+++ b/apps/client/test/core/ui/adaptive_dialog_test.dart
@@ -2,7 +2,6 @@
 // 方案: docs/BiuMind-Mobile-Adaptation-Plan.md §4.5
 
 import 'package:flutter/material.dart' hide showAdaptiveDialog;
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/core/ui/adaptive_dialog.dart';

--- a/apps/client/test/core/ui/biu_card_tile_test.dart
+++ b/apps/client/test/core/ui/biu_card_tile_test.dart
@@ -1,8 +1,6 @@
 // BiuCard / BiuTile widget tests — 验证默认 / hover / selected 三态。
 
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/app/theme/font_size.dart';

--- a/apps/client/test/core/ui/biu_helpers_test.dart
+++ b/apps/client/test/core/ui/biu_helpers_test.dart
@@ -1,8 +1,6 @@
 // 基础组件 widget tests — 确保 Phase A helpers 不崩 + 关键属性透传。
 
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/app/theme/effects.dart';

--- a/apps/client/test/core/ui/biu_input_chip_test.dart
+++ b/apps/client/test/core/ui/biu_input_chip_test.dart
@@ -1,8 +1,6 @@
 // BiuTextField + BiuChip widget tests。
 
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/app/theme/font_size.dart';

--- a/apps/client/test/data/agent_plane/agent_plane_client_test.dart
+++ b/apps/client/test/data/agent_plane/agent_plane_client_test.dart
@@ -2,11 +2,9 @@
 // agentplane API 形状对齐。覆盖 list / create session / refresh token /
 // 错误响应。
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/agent_plane/agent_plane_client.dart';

--- a/apps/client/test/data/agent_plane/biu_daemon_manager_test.dart
+++ b/apps/client/test/data/agent_plane/biu_daemon_manager_test.dart
@@ -4,16 +4,12 @@
 // 不模拟 binary 查找：注入 binaryResolver 直接给 sh 路径。
 // 不模拟 brain 注册：daemon 跑的是 sh stub，不真调 brain。
 
-@TestOn('vm')
-
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:biumind/data/agent_plane/biu_daemon_manager.dart';
 import 'package:crypto/crypto.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/apps/client/test/data/agent_plane/environment_repo_test.dart
+++ b/apps/client/test/data/agent_plane/environment_repo_test.dart
@@ -3,9 +3,7 @@
 //
 // 真 HTTP wire 由 agent_plane_client_test.dart 覆盖（in-process HttpServer）。
 
-import 'dart:async';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/agent_plane/agent_plane_client.dart';

--- a/apps/client/test/data/agui_event_test.dart
+++ b/apps/client/test/data/agui_event_test.dart
@@ -1,5 +1,4 @@
 import 'package:biumind/data/sse/agui_event.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/data/api/billing_error_hook_test.dart
+++ b/apps/client/test/data/api/billing_error_hook_test.dart
@@ -4,11 +4,9 @@
 // 起一个 in-process HttpServer 按 path 返回不同错误体, 用 apiRequest 打它,
 // 断言 billingErrorHandler 是否被调 + 参数。
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:biumind/data/api/_http_helpers.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/data/api/biu_client_test.dart
+++ b/apps/client/test/data/api/biu_client_test.dart
@@ -12,7 +12,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/api/biu_client.dart';

--- a/apps/client/test/data/api/chat_client_search_test.dart
+++ b/apps/client/test/data/api/chat_client_search_test.dart
@@ -6,7 +6,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/api/chat_client.dart';

--- a/apps/client/test/data/api/memory_client_test.dart
+++ b/apps/client/test/data/api/memory_client_test.dart
@@ -9,7 +9,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/api/memory_client.dart';

--- a/apps/client/test/data/api/sdkproto_roundtrip_test.dart
+++ b/apps/client/test/data/api/sdkproto_roundtrip_test.dart
@@ -13,7 +13,6 @@ import 'package:biumind/data/api/sdkproto/v1/data/system.dart';
 import 'package:biumind/data/api/sdkproto/v1/data/user.dart';
 import 'package:biumind/data/api/sdkproto/v1/lifecycle.dart';
 import 'package:biumind/data/api/sdkproto/v1/service.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/data/api/skill_client_test.dart
+++ b/apps/client/test/data/api/skill_client_test.dart
@@ -6,7 +6,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/api/skill_client.dart';

--- a/apps/client/test/data/hub_backend_test.dart
+++ b/apps/client/test/data/hub_backend_test.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:biumind/core/ai/ai_surface.dart';
 import 'package:biumind/data/api/hub_backend.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Spawns a local HttpServer that emits a scripted SSE response when

--- a/apps/client/test/data/local/migration_v22_to_v26_test.dart
+++ b/apps/client/test/data/local/migration_v22_to_v26_test.dart
@@ -21,7 +21,6 @@
 
 import 'package:biumind/data/local/db.dart';
 import 'package:drift/native.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqlite3/sqlite3.dart';
 

--- a/apps/client/test/data/sse/realtime_hub_test.dart
+++ b/apps/client/test/data/sse/realtime_hub_test.dart
@@ -7,7 +7,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' show MockClient, MockClientHandler;
@@ -438,7 +437,7 @@ void main() {
         }),
         loadLastEventId: () async => null,
         saveLastEventId: (_) async {},
-        onDesync: (_, __) async {},
+        onDesync: (_, _) async {},
       );
 
       final framesA = <RealtimeFrame>[];
@@ -478,7 +477,7 @@ void main() {
             _StreamingMockClient((_) async => _sseResponse(ctrl.stream)),
         loadLastEventId: () async => null,
         saveLastEventId: (_) async {},
-        onDesync: (_, __) async => throw Exception('refetch failed'),
+        onDesync: (_, _) async => throw Exception('refetch failed'),
       );
 
       final frames = <RealtimeFrame>[];

--- a/apps/client/test/data/wiki_client_test.dart
+++ b/apps/client/test/data/wiki_client_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:biumind/data/api/wiki_client.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _FakeWiki {

--- a/apps/client/test/data/wiki_local_test.dart
+++ b/apps/client/test/data/wiki_local_test.dart
@@ -12,7 +12,6 @@ import 'package:biumind/data/local/db.dart';
 import 'package:biumind/data/local/wiki_dao.dart';
 import 'package:biumind/data/outbox/wiki_outbox_flusher.dart';
 import 'package:biumind/data/wiki_repository.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _FakeWiki {

--- a/apps/client/test/features/apps/a2ui_renderer_test.dart
+++ b/apps/client/test/features/apps/a2ui_renderer_test.dart
@@ -9,9 +9,7 @@ import 'package:biumind/features/apps/domain/view_spec.dart';
 import 'package:biumind/features/apps/host/a2ui_renderer.dart';
 import 'package:biumind/features/apps/host/action_runner.dart';
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _CapturingRunner extends ActionRunner {

--- a/apps/client/test/features/apps/a2ui_test.dart
+++ b/apps/client/test/features/apps/a2ui_test.dart
@@ -4,7 +4,6 @@
 // stays parse-layer-only (fast, runs without a Flutter binding).
 
 import 'package:biumind/features/apps/domain/a2ui.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/apps/add_webview_dialog_test.dart
+++ b/apps/client/test/features/apps/add_webview_dialog_test.dart
@@ -8,9 +8,7 @@
 
 import 'package:biumind/features/apps/presentation/add_webview_dialog.dart';
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Widget _wrap(Widget child) => ProviderScope(

--- a/apps/client/test/features/apps/builtin/rss/entries_pane_gesture_test.dart
+++ b/apps/client/test/features/apps/builtin/rss/entries_pane_gesture_test.dart
@@ -10,9 +10,7 @@ import 'package:biumind/features/apps/builtin/rss/models.dart';
 import 'package:biumind/features/apps/builtin/rss/providers.dart';
 import 'package:biumind/features/apps/builtin/rss/widgets/entries_pane.dart';
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _FakeRssApi extends RssApi {

--- a/apps/client/test/features/apps/builtin/rss/latex_html_test.dart
+++ b/apps/client/test/features/apps/builtin/rss/latex_html_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:biumind/features/apps/builtin/rss/widgets/latex_html.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // 从 injectDisplayTex 产物里抽出第一个 <x-tex> 的 latex 源码(base64 解码)。

--- a/apps/client/test/features/apps/builtin/rss/latex_render_test.dart
+++ b/apps/client/test/features/apps/builtin/rss/latex_render_test.dart
@@ -3,9 +3,7 @@
 
 import 'package:biumind/features/apps/builtin/rss/widgets/latex_html.dart';
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 

--- a/apps/client/test/features/apps/builtin/rss/transcript_segments_test.dart
+++ b/apps/client/test/features/apps/builtin/rss/transcript_segments_test.dart
@@ -1,7 +1,6 @@
 // M13.5 Tier2 — Entry.fromJson parses transcript_segments for synced playback.
 
 import 'package:biumind/features/apps/builtin/rss/models.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/apps/dev_apps_provider_test.dart
+++ b/apps/client/test/features/apps/dev_apps_provider_test.dart
@@ -6,7 +6,6 @@
 // the dev list.
 
 import 'package:biumind/data/dev_apps_provider.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/apps/interpolator_test.dart
+++ b/apps/client/test/features/apps/interpolator_test.dart
@@ -4,7 +4,6 @@
 // asserts here are deliberately tight.
 
 import 'package:biumind/features/apps/domain/interpolator.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/apps/layouts_v2_test.dart
+++ b/apps/client/test/features/apps/layouts_v2_test.dart
@@ -10,9 +10,7 @@ import 'package:biumind/features/apps/domain/view_spec.dart';
 import 'package:biumind/features/apps/host/action_runner.dart';
 import 'package:biumind/features/apps/host/layouts_v2.dart';
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 ActionRunner _stubRunner(WidgetRef ref) => ActionRunner(

--- a/apps/client/test/features/apps/rss_cache_dao_test.dart
+++ b/apps/client/test/features/apps/rss_cache_dao_test.dart
@@ -1,7 +1,6 @@
 // M10.1 RssCacheDao 单测 — 用 AppDb.memory() 跑真 sqlite (内存), 验证
 // upsert / read / scope 隔离 / TTL / 总量裁剪 / replace 语义.
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:biumind/data/local/db.dart';
 import 'package:biumind/features/apps/builtin/rss/data/rss_cache_dao.dart';

--- a/apps/client/test/features/apps/sidebar_badges_test.dart
+++ b/apps/client/test/features/apps/sidebar_badges_test.dart
@@ -4,7 +4,6 @@
 // provider 异步, 留 widget integration test; 这里只覆盖纯函数。
 
 import 'package:biumind/data/sidebar_badges.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/apps/sidebar_outbox_test.dart
+++ b/apps/client/test/features/apps/sidebar_outbox_test.dart
@@ -5,7 +5,6 @@
 
 import 'package:biumind/data/api/sidebar_client.dart';
 import 'package:biumind/data/sidebar_outbox.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/apps/view_spec_test.dart
+++ b/apps/client/test/features/apps/view_spec_test.dart
@@ -4,7 +4,6 @@
 // catch them at the parsing seam.
 
 import 'package:biumind/features/apps/domain/view_spec.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/chat/application/attachments_provider_test.dart
+++ b/apps/client/test/features/chat/application/attachments_provider_test.dart
@@ -2,7 +2,6 @@
 
 import 'dart:typed_data';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/application/attachments_provider.dart';

--- a/apps/client/test/features/chat/application/chat_controller_test.dart
+++ b/apps/client/test/features/chat/application/chat_controller_test.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/agent_plane/agent_plane_client.dart';

--- a/apps/client/test/features/chat/application/chat_preferences_test.dart
+++ b/apps/client/test/features/chat/application/chat_preferences_test.dart
@@ -1,6 +1,5 @@
 // ChatPreferences —— 全局偏好单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/apps/client/test/features/chat/application/composer_draft_store_test.dart
+++ b/apps/client/test/features/chat/application/composer_draft_store_test.dart
@@ -1,6 +1,5 @@
 // ComposerDraftStore —— per-thread 草稿单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/apps/client/test/features/chat/application/draft_history_test.dart
+++ b/apps/client/test/features/chat/application/draft_history_test.dart
@@ -1,6 +1,5 @@
 // DraftHistoryNotifier —— P0-6 composer 历史栈单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/apps/client/test/features/chat/application/in_thread_search_test.dart
+++ b/apps/client/test/features/chat/application/in_thread_search_test.dart
@@ -1,6 +1,5 @@
 // InThreadSearchController —— Cmd+F 线程内搜索状态机单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/application/in_thread_search_controller.dart';

--- a/apps/client/test/features/chat/application/new_thread_memory_test.dart
+++ b/apps/client/test/features/chat/application/new_thread_memory_test.dart
@@ -1,6 +1,5 @@
 // NewThreadMemory —— NewThreadDialog 字段记忆单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/apps/client/test/features/chat/application/prompt_template_store_test.dart
+++ b/apps/client/test/features/chat/application/prompt_template_store_test.dart
@@ -1,6 +1,5 @@
 // PromptTemplateStore —— system prompt 模板单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/apps/client/test/features/chat/application/selection_mode_test.dart
+++ b/apps/client/test/features/chat/application/selection_mode_test.dart
@@ -1,6 +1,5 @@
 // SelectionModeNotifier —— P0-3 多选状态机单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/application/selection_mode_controller.dart';

--- a/apps/client/test/features/chat/application/web_search_provider_test.dart
+++ b/apps/client/test/features/chat/application/web_search_provider_test.dart
@@ -1,6 +1,5 @@
 // WebSearchHint —— 联网搜索一次性开关单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/application/web_search_provider.dart';

--- a/apps/client/test/features/chat/avatar_meta_test.dart
+++ b/apps/client/test/features/chat/avatar_meta_test.dart
@@ -6,8 +6,6 @@
 //   * resolveUserAvatar 三档 (name / email / 都空)
 
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/avatar_meta.dart';

--- a/apps/client/test/features/chat/billing_estimate_test.dart
+++ b/apps/client/test/features/chat/billing_estimate_test.dart
@@ -1,6 +1,5 @@
 // Test ChatEstimate display logic.
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/data/billing_estimate_client.dart';

--- a/apps/client/test/features/chat/data/archive_stats_test.dart
+++ b/apps/client/test/features/chat/data/archive_stats_test.dart
@@ -1,7 +1,6 @@
 // ChatRepo —— 归档管理 + 统计单测。
 
 import 'package:drift/drift.dart' show Value;
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/local/db.dart';

--- a/apps/client/test/features/chat/data/biu_session_connection_test.dart
+++ b/apps/client/test/features/chat/data/biu_session_connection_test.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 

--- a/apps/client/test/features/chat/data/chat_repo_test.dart
+++ b/apps/client/test/features/chat/data/chat_repo_test.dart
@@ -1,7 +1,6 @@
 // ChatRepo R1 单测 —— AppDb.memory() 内存 sqlite，每个测试一个 fresh db。
 // 覆盖 thread / message / block / session 的 CRUD + watch reactivity。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/local/db.dart';

--- a/apps/client/test/features/chat/data/reactions_test.dart
+++ b/apps/client/test/features/chat/data/reactions_test.dart
@@ -1,7 +1,6 @@
 // ChatRepo reactions —— P0-1 单测。
 // 设计文档 docs/BiuMind-Chat-UI-Benchmark-Optimization.md。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/local/db.dart';

--- a/apps/client/test/features/chat/data/search_messages_test.dart
+++ b/apps/client/test/features/chat/data/search_messages_test.dart
@@ -1,7 +1,6 @@
 // ChatRepo.searchMessages —— 跨会话搜索单测。
 
 import 'package:drift/drift.dart' show Value;
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/local/db.dart';

--- a/apps/client/test/features/chat/data/system_prompt_test.dart
+++ b/apps/client/test/features/chat/data/system_prompt_test.dart
@@ -1,6 +1,5 @@
 // ChatRepo.setSystemPrompt —— P0-补 Thread 设置 sheet 后端单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/local/db.dart';

--- a/apps/client/test/features/chat/domain/greeting_test.dart
+++ b/apps/client/test/features/chat/domain/greeting_test.dart
@@ -1,6 +1,5 @@
 // Greeting —— Hero 欢迎页问候语 + 相对时间单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/greeting.dart';

--- a/apps/client/test/features/chat/domain/message_outline_test.dart
+++ b/apps/client/test/features/chat/domain/message_outline_test.dart
@@ -1,6 +1,5 @@
 // MessageOutline —— markdown heading 提取单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/message_outline.dart';

--- a/apps/client/test/features/chat/domain/palette_actions_test.dart
+++ b/apps/client/test/features/chat/domain/palette_actions_test.dart
@@ -1,6 +1,5 @@
 // PaletteAction —— Cmd+K 命令面板过滤逻辑单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/palette_actions.dart';

--- a/apps/client/test/features/chat/domain/reasoning_parser_test.dart
+++ b/apps/client/test/features/chat/domain/reasoning_parser_test.dart
@@ -1,6 +1,5 @@
 // ReasoningParser —— `<think>` 标签解析单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/reasoning_parser.dart';

--- a/apps/client/test/features/chat/domain/slash_commands_test.dart
+++ b/apps/client/test/features/chat/domain/slash_commands_test.dart
@@ -1,6 +1,5 @@
 // SlashCommands —— composer 斜杠命令解析单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/slash_commands.dart';

--- a/apps/client/test/features/chat/domain/thread_export_json_test.dart
+++ b/apps/client/test/features/chat/domain/thread_export_json_test.dart
@@ -1,6 +1,5 @@
 // thread_export_json —— 会话导入导出 round-trip 单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/chat_models.dart';

--- a/apps/client/test/features/chat/domain/thread_filter_test.dart
+++ b/apps/client/test/features/chat/domain/thread_filter_test.dart
@@ -1,6 +1,5 @@
 // thread_filter —— sidebar 过滤 + pin 分组单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/chat_models.dart';

--- a/apps/client/test/features/chat/domain/thread_title_test.dart
+++ b/apps/client/test/features/chat/domain/thread_title_test.dart
@@ -1,6 +1,5 @@
 // titleFromPrompt —— thread 自动改名单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/thread_title.dart';

--- a/apps/client/test/features/chat/domain/token_estimate_test.dart
+++ b/apps/client/test/features/chat/domain/token_estimate_test.dart
@@ -1,6 +1,5 @@
 // TokenEstimate —— 启发式 token 估算单测。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/chat/domain/token_estimate.dart';

--- a/apps/client/test/features/chat/markdown/pre_normalize_test.dart
+++ b/apps/client/test/features/chat/markdown/pre_normalize_test.dart
@@ -1,6 +1,5 @@
 // pre_normalize 5 条规则的单测。Fixture 来自实际 AI 输出。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:biumind/features/chat/markdown/pre_normalize.dart';
 

--- a/apps/client/test/features/chat/markdown/split_segments_test.dart
+++ b/apps/client/test/features/chat/markdown/split_segments_test.dart
@@ -1,6 +1,5 @@
 // split_segments 测试: R1-R7 + math 块 + markdown 兜底 + 流式 closed=false。
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:biumind/features/chat/markdown/segments.dart';
 import 'package:biumind/features/chat/markdown/split_segments.dart';

--- a/apps/client/test/features/chat/markdown_render_test.dart
+++ b/apps/client/test/features/chat/markdown_render_test.dart
@@ -15,9 +15,7 @@
 //      replaces gpt_markdown's default hard-bordered renderer).
 
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 

--- a/apps/client/test/features/code/agent_status_event_test.dart
+++ b/apps/client/test/features/code/agent_status_event_test.dart
@@ -1,7 +1,6 @@
 // AgentStatus 事件解析/回写测试(PERI-1d)。daemon hook watcher 发
 // {type:agent_status,status:running|input_required},客户端据此可靠切换任务状态。
 import 'package:biumind/features/code/domain/code_task.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/bridge_terminal_adapter_test.dart
+++ b/apps/client/test/features/code/bridge_terminal_adapter_test.dart
@@ -13,7 +13,6 @@ import 'dart:convert';
 import 'package:biumind/features/code/agent/bridge_terminal_adapter.dart';
 import 'package:biumind/features/code/data/code_bridge_client.dart';
 import 'package:biumind/features/code/domain/code_task.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class FakeCodeTransport implements CodeTransport {

--- a/apps/client/test/features/code/code_bridge_client_test.dart
+++ b/apps/client/test/features/code/code_bridge_client_test.dart
@@ -13,7 +13,6 @@ import 'dart:convert';
 
 import 'package:biumind/data/api/sdkproto/v1/code.dart';
 import 'package:biumind/features/code/data/code_bridge_client.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class FakeCodeTransport implements CodeTransport {

--- a/apps/client/test/features/code/code_bridge_loopback_test.dart
+++ b/apps/client/test/features/code/code_bridge_loopback_test.dart
@@ -14,7 +14,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:biumind/features/code/data/code_bridge_client.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/code_latency_bench_test.dart
+++ b/apps/client/test/features/code/code_latency_bench_test.dart
@@ -14,7 +14,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:biumind/features/code/data/code_bridge_client.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/code_projects_dao_test.dart
+++ b/apps/client/test/features/code/code_projects_dao_test.dart
@@ -3,7 +3,6 @@
 import 'package:biumind/data/local/db.dart';
 import 'package:biumind/features/code/data/code_projects_dao.dart';
 import 'package:biumind/features/code/domain/project.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/code_runtask_e2e_test.dart
+++ b/apps/client/test/features/code/code_runtask_e2e_test.dart
@@ -20,7 +20,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:biumind/features/code/data/code_bridge_client.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/code_task_artifacts_dao_test.dart
+++ b/apps/client/test/features/code/code_task_artifacts_dao_test.dart
@@ -3,7 +3,6 @@
 import 'package:biumind/data/local/db.dart';
 import 'package:biumind/features/code/data/code_task_artifacts_dao.dart';
 import 'package:biumind/features/code/domain/artifact.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/code_tasks_dao_test.dart
+++ b/apps/client/test/features/code/code_tasks_dao_test.dart
@@ -3,7 +3,6 @@
 import 'package:biumind/data/local/db.dart';
 import 'package:biumind/features/code/data/code_tasks_dao.dart';
 import 'package:biumind/features/code/domain/code_task.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/cost_update_context_test.dart
+++ b/apps/client/test/features/code/cost_update_context_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:biumind/features/code/domain/code_task.dart';
 

--- a/apps/client/test/features/code/file_explorer_controller_test.dart
+++ b/apps/client/test/features/code/file_explorer_controller_test.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 
 import 'package:biumind/features/code/application/file_explorer_controller.dart';
 import 'package:biumind/features/code/data/code_bridge_client.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class AutoRespondTransport implements CodeTransport {
@@ -31,7 +30,7 @@ class AutoRespondTransport implements CodeTransport {
         'type': 'code_response',
         'request_id': id,
         'ok': result != null,
-        if (result != null) 'result': result,
+        'result': ?result,
         if (result == null) 'error': 'no canned for $method',
       }));
     });

--- a/apps/client/test/features/code/files_client_presign_test.dart
+++ b/apps/client/test/features/code/files_client_presign_test.dart
@@ -14,7 +14,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/code/data/files_client.dart';

--- a/apps/client/test/features/code/git_controller_test.dart
+++ b/apps/client/test/features/code/git_controller_test.dart
@@ -9,7 +9,6 @@ import 'dart:convert';
 import 'package:biumind/features/code/application/git_controller.dart';
 import 'package:biumind/features/code/data/code_bridge_client.dart';
 import 'package:biumind/features/code/domain/git_models.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// 按 method 给 canned result 的自动应答 transport。
@@ -38,7 +37,7 @@ class AutoRespondTransport implements CodeTransport {
         'type': 'code_response',
         'request_id': id,
         'ok': result != null,
-        if (result != null) 'result': result,
+        'result': ?result,
         if (result == null) 'error': 'no canned response for $method',
       }));
     });

--- a/apps/client/test/features/code/incremental_utf8_test.dart
+++ b/apps/client/test/features/code/incremental_utf8_test.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:biumind/features/code/data/incremental_utf8.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Uint8List bytes(String s) => Uint8List.fromList(utf8.encode(s));

--- a/apps/client/test/features/code/local_git_worktree_migration_test.dart
+++ b/apps/client/test/features/code/local_git_worktree_migration_test.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:biumind/features/code/data/code_bridge_client.dart';
 import 'package:biumind/features/code/workspace/local_git_worktree.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class AutoRespondTransport implements CodeTransport {
@@ -35,7 +34,7 @@ class AutoRespondTransport implements CodeTransport {
         'type': 'code_response',
         'request_id': id,
         'ok': result != null,
-        if (result != null) 'result': result,
+        'result': ?result,
         if (result == null) 'error': 'no canned for $method',
       }));
     });

--- a/apps/client/test/features/code/passthrough_workspace_test.dart
+++ b/apps/client/test/features/code/passthrough_workspace_test.dart
@@ -10,7 +10,6 @@ import 'dart:io';
 
 import 'package:biumind/features/code/domain/artifact.dart';
 import 'package:biumind/features/code/workspace/passthrough_workspace.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 

--- a/apps/client/test/features/code/preview_generator_test.dart
+++ b/apps/client/test/features/code/preview_generator_test.dart
@@ -14,7 +14,6 @@ import 'dart:typed_data';
 
 import 'package:biumind/features/code/domain/artifact.dart';
 import 'package:biumind/features/code/workspace/preview_generator.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 import 'package:path/path.dart' as p;

--- a/apps/client/test/features/code/preview_sensitive_test.dart
+++ b/apps/client/test/features/code/preview_sensitive_test.dart
@@ -2,7 +2,6 @@
 // 匹配规则。规则放宽 (保守拒) 比放紧好, 但误伤要可预测。
 
 import 'package:biumind/features/code/workspace/preview_generator.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/project_scope_test.dart
+++ b/apps/client/test/features/code/project_scope_test.dart
@@ -3,7 +3,6 @@
 
 import 'package:biumind/features/code/application/projects_controller.dart';
 import 'package:biumind/features/code/domain/code_task.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 CodeTask task(String id, String? projectId) => CodeTask(

--- a/apps/client/test/features/code/projects_controller_test.dart
+++ b/apps/client/test/features/code/projects_controller_test.dart
@@ -4,7 +4,6 @@
 import 'package:biumind/data/local/db.dart';
 import 'package:biumind/features/code/application/projects_controller.dart';
 import 'package:biumind/features/code/data/code_projects_dao.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/resume_session_test.dart
+++ b/apps/client/test/features/code/resume_session_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:biumind/features/code/domain/code_task.dart';
 

--- a/apps/client/test/features/code/session_export_test.dart
+++ b/apps/client/test/features/code/session_export_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:biumind/features/code/application/session_export.dart';
 import 'package:biumind/features/code/domain/code_task.dart';

--- a/apps/client/test/features/code/shell_terminal_controller_test.dart
+++ b/apps/client/test/features/code/shell_terminal_controller_test.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 
 import 'package:biumind/features/code/application/shell_terminal_controller.dart';
 import 'package:biumind/features/code/data/code_bridge_client.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class FakeCodeTransport implements CodeTransport {

--- a/apps/client/test/features/code/shell_terminal_e2e_test.dart
+++ b/apps/client/test/features/code/shell_terminal_e2e_test.dart
@@ -13,7 +13,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:biumind/features/code/data/code_bridge_client.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/code/timeline_builder_test.dart
+++ b/apps/client/test/features/code/timeline_builder_test.dart
@@ -2,7 +2,6 @@
 
 import 'package:biumind/features/code/application/timeline_builder.dart';
 import 'package:biumind/features/code/domain/code_task.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 CodeTask t(String id, String? projectId, DateTime updated) => CodeTask(

--- a/apps/client/test/features/creation/aigc_tasks_dao_test.dart
+++ b/apps/client/test/features/creation/aigc_tasks_dao_test.dart
@@ -1,7 +1,6 @@
 // AigcTasksDao — drift 持久化层单测.
 // 用 AppDb.memory() 跑 in-memory sqlite, 不依赖文件系统.
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/local/db.dart';

--- a/apps/client/test/features/creation/character_dialog_test.dart
+++ b/apps/client/test/features/creation/character_dialog_test.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/creation/application/aigc_providers.dart';

--- a/apps/client/test/features/creation/connection_banner_test.dart
+++ b/apps/client/test/features/creation/connection_banner_test.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/creation/presentation/widgets/connection_banner.dart';

--- a/apps/client/test/features/creation/creation_card_test.dart
+++ b/apps/client/test/features/creation/creation_card_test.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/creation/domain/creation_task.dart';

--- a/apps/client/test/features/creation/error_translator_test.dart
+++ b/apps/client/test/features/creation/error_translator_test.dart
@@ -2,7 +2,6 @@
 
 import 'dart:io' show SocketException;
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/data/api/_http_helpers.dart';

--- a/apps/client/test/features/creation/generation_form_controller_test.dart
+++ b/apps/client/test/features/creation/generation_form_controller_test.dart
@@ -2,7 +2,6 @@
 
 import 'package:biumind/features/creation/application/generation_form_controller.dart';
 import 'package:biumind/features/creation/domain/ai_model.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 AiModel _videoModel() {

--- a/apps/client/test/features/creation/generation_panel_test.dart
+++ b/apps/client/test/features/creation/generation_panel_test.dart
@@ -5,7 +5,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/creation/application/aigc_providers.dart';

--- a/apps/client/test/features/creation/pages_test.dart
+++ b/apps/client/test/features/creation/pages_test.dart
@@ -5,7 +5,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/creation/application/aigc_providers.dart';

--- a/apps/client/test/features/creation/tasks_controller_test.dart
+++ b/apps/client/test/features/creation/tasks_controller_test.dart
@@ -9,7 +9,6 @@ import 'package:biumind/data/sse/sse_cursors_dao.dart';
 import 'package:biumind/features/creation/application/tasks_controller.dart';
 import 'package:biumind/features/creation/data/aigc_client.dart';
 import 'package:biumind/features/creation/domain/creation_task.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _FakeAigcClient extends AigcClient {

--- a/apps/client/test/features/membership/coupons_referrals_test.dart
+++ b/apps/client/test/features/membership/coupons_referrals_test.dart
@@ -1,9 +1,7 @@
 // W6-13 客户端 — 6 widget / model 测试.
 
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/membership/domain/coupon.dart';

--- a/apps/client/test/features/membership/membership_client_test.dart
+++ b/apps/client/test/features/membership/membership_client_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:convert';
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/membership/domain/plan.dart';

--- a/apps/client/test/features/membership/membership_widgets_test.dart
+++ b/apps/client/test/features/membership/membership_widgets_test.dart
@@ -3,8 +3,6 @@
 // upgrade_modal / order_history_page (smoke) / plan_compare_page (smoke).
 
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/membership/domain/checkout.dart';

--- a/apps/client/test/features/membership/quota_progress_test.dart
+++ b/apps/client/test/features/membership/quota_progress_test.dart
@@ -1,8 +1,6 @@
 // W4-7 quota_progress widget tests — 进度条 0/half/full + free fallback.
 
 import 'package:flutter/material.dart';
-import 'package:biumind/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/membership/domain/subscription.dart';

--- a/apps/client/test/features/settings/api_keys_test.dart
+++ b/apps/client/test/features/settings/api_keys_test.dart
@@ -1,6 +1,5 @@
 // Test ApiKeyEntry parsing + status mapping.
 
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/settings/data/api_keys_client.dart';

--- a/apps/client/test/features/skills/sync/skill_events_realtime_test.dart
+++ b/apps/client/test/features/skills/sync/skill_events_realtime_test.dart
@@ -6,7 +6,6 @@
 import 'dart:convert';
 
 import 'package:biumind/features/skills/sync/skill_events_realtime.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/update/release_manifest_test.dart
+++ b/apps/client/test/features/update/release_manifest_test.dart
@@ -4,7 +4,6 @@
 // 覆盖 schema/release/v1 契约的关键字段。纯逻辑无网络/mock。
 
 import 'package:biumind/features/update/domain/release_manifest.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pub_semver/pub_semver.dart';
 

--- a/apps/client/test/features/wiki/block_to_markdown_test.dart
+++ b/apps/client/test/features/wiki/block_to_markdown_test.dart
@@ -1,6 +1,5 @@
 import 'package:biumind/data/wiki_repository.dart';
 import 'package:biumind/features/wiki/presentation/reader/block_to_markdown.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 RepoBlock _block({

--- a/apps/client/test/features/wiki/frontmatter_helpers_test.dart
+++ b/apps/client/test/features/wiki/frontmatter_helpers_test.dart
@@ -1,5 +1,4 @@
 import 'package:biumind/features/wiki/presentation/frontmatter/frontmatter_helpers.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/features/wiki/mermaid_url_test.dart
+++ b/apps/client/test/features/wiki/mermaid_url_test.dart
@@ -6,7 +6,6 @@
 
 import 'dart:convert';
 import 'package:archive/archive.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/features/wiki/presentation/mermaid/mermaid_url.dart';

--- a/apps/client/test/features/wiki/wiki_search_test.dart
+++ b/apps/client/test/features/wiki/wiki_search_test.dart
@@ -1,6 +1,5 @@
 import 'package:biumind/data/wiki_repository.dart';
 import 'package:biumind/features/wiki/application/wiki_search.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 RepoPage _page({

--- a/apps/client/test/features/wiki/wikilink_parser_test.dart
+++ b/apps/client/test/features/wiki/wikilink_parser_test.dart
@@ -1,5 +1,4 @@
 import 'package:biumind/features/wiki/presentation/wikilink/wikilink_parser.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/apps/client/test/l10n/app_localizations_test.dart
+++ b/apps/client/test/l10n/app_localizations_test.dart
@@ -5,7 +5,6 @@
 // widget tree wiring and run sub-millisecond.
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:biumind/l10n/app_localizations.dart';

--- a/apps/client/test/services/settings_repo_test.dart
+++ b/apps/client/test/services/settings_repo_test.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:biumind/services/settings_repo.dart';
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// 可控故障的 fake secure storage — 模拟 Android ROM/备份恢复后 keychain

--- a/apps/client/test/services/token_refresher_test.dart
+++ b/apps/client/test/services/token_refresher_test.dart
@@ -4,7 +4,6 @@
 // fallback:ttl null/0 → 5min margin / 1min tick。
 
 import 'package:biumind/services/token_refresher.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
Flutter workflow 的 analyze step 从建仓起从未绿过（205 个 warning，非依赖升级引入）。本 PR 清零：

- 137 个 unused_import + 24 个 use_null_aware_elements 等机械类问题：`dart fix --apply`（169 fixes / 127 文件，大头是测试文件残留的 l10n 样板 import）
- `tasks_controller.dart`：`deleteTask` 从 extension 移入 `CodeTasksController` 类内（extension 内访问 `StateNotifier.state` 触发 invalid_use_of_protected_member）
- `assets/editor/` 目录不存在：该目录是 `make editor-web-build` 生成产物且运行时会被 `editor_native_view.dart` 引用，故不删 pubspec 声明，改为 `.gitignore` 放行两级 `.gitkeep`
- 14 处 doc comment `<...>` 加反引号；8 处 use_build_context_synchronously 加守卫或改官方推荐写法；6 处 deprecated Radio API 迁到 RadioGroup

验证：`flutter analyze --no-pub` → No issues found（exit 0）；`flutter test --no-pub` → 1399/1399 全过，与基线一致。
