### PR TITLE
fix(ci): resolve long-standing Go workflow failures

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,7 @@ jobs:
           - packages/go-sdk/biu
           - services/authz
           - services/brain
-          - services/hub
+          - services/model-relay
           - services/identity
           - services/realtime
           - services/runtime
@@ -94,6 +94,29 @@ jobs:
           # Apply the goose-marked migrations in order; we strip the
           # +goose pragmas with sed so plain psql executes them.
           for f in services/brain/migrations/*.sql; do
+            echo "-- applying $f --"
+            sed -e '/^-- +goose Down/,$d' \
+                -e '/^-- +goose Up/d' \
+                -e '/^-- +goose StatementBegin/d' \
+                -e '/^-- +goose StatementEnd/d' \
+                "$f" | psql -v ON_ERROR_STOP=1
+          done
+
+      - name: Apply app_center.* schema (modules that need it)
+        if: matrix.module == 'services/app_center'
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: biumind
+          PGPASSWORD: biumind_ci
+          PGDATABASE: biu_core
+        run: |
+          # Extensions + schemas are created by the baseline migration
+          # itself; only the pgvector image's `vector` extension must
+          # be loadable.
+          # Apply the goose-marked migrations in order; we strip the
+          # +goose pragmas with sed so plain psql executes them.
+          for f in services/app_center/migrations/*.sql; do
             echo "-- applying $f --"
             sed -e '/^-- +goose Down/,$d' \
                 -e '/^-- +goose Up/d' \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
           - packages/go-sdk/biu
           - services/authz
           - services/brain
-          - services/hub
+          - services/model-relay
           - services/identity
           - services/realtime
           - services/runtime

--- a/apps/cli/biu/internal/bridge/server_test.go
+++ b/apps/cli/biu/internal/bridge/server_test.go
@@ -56,7 +56,10 @@ func TestAuthMiddlewareBlocks(t *testing.T) {
 	ts := newTestServer(t, "secret")
 	defer ts.Close()
 
-	resp, _ := http.Post(ts.URL+"/v1/code/sessions", "application/json", nil)
+	resp, err := http.Post(ts.URL+"/v1/code/sessions", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("missing token must 401, got %d", resp.StatusCode)
@@ -64,7 +67,10 @@ func TestAuthMiddlewareBlocks(t *testing.T) {
 
 	req, _ := http.NewRequest("POST", ts.URL+"/v1/code/sessions", nil)
 	req.Header.Set("Authorization", "Bearer secret")
-	resp2, _ := http.DefaultClient.Do(req)
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp2.Body.Close()
 	if resp2.StatusCode != http.StatusCreated {
 		t.Errorf("valid token must 201, got %d", resp2.StatusCode)
@@ -105,9 +111,12 @@ func TestSubmitRejectsEmptyPrompt(t *testing.T) {
 	_ = json.NewDecoder(resp.Body).Decode(&c)
 	resp.Body.Close()
 
-	r2, _ := http.Post(
+	r2, err := http.Post(
 		ts.URL+"/v1/code/sessions/"+c.ID+"/messages",
 		"application/json", bytes.NewReader([]byte(`{"prompt":""}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer r2.Body.Close()
 	if r2.StatusCode != http.StatusBadRequest {
 		t.Errorf("blank prompt should 400, got %d", r2.StatusCode)
@@ -137,7 +146,10 @@ func TestCostEndpointReturnsSnapshot(t *testing.T) {
 	_ = json.NewDecoder(resp.Body).Decode(&c)
 	resp.Body.Close()
 
-	r2, _ := http.Get(ts.URL + "/v1/code/sessions/" + c.ID + "/cost")
+	r2, err := http.Get(ts.URL + "/v1/code/sessions/" + c.ID + "/cost")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer r2.Body.Close()
 	if r2.StatusCode != http.StatusOK {
 		t.Fatalf("cost = %d", r2.StatusCode)

--- a/apps/cli/biu/internal/devserver/devserver_test.go
+++ b/apps/cli/biu/internal/devserver/devserver_test.go
@@ -78,7 +78,10 @@ func TestUpsertAndList(t *testing.T) {
 	s := startTestServer(t, nil)
 	s.UpsertApp(DevApp{Slug: "rss", Identifier: "rss", Title: "RSS", Version: "0.1.0"})
 	s.UpsertApp(DevApp{Slug: "tasks", Identifier: "tasks", Title: "Tasks", Version: "0.2.0"})
-	resp, _ := http.Get("http://" + s.Addr() + "/v1/dev/apps")
+	resp, err := http.Get("http://" + s.Addr() + "/v1/dev/apps")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	var body struct{ Apps []DevApp }
 	_ = json.NewDecoder(resp.Body).Decode(&body)
@@ -87,7 +90,10 @@ func TestUpsertAndList(t *testing.T) {
 	}
 	// SetApps should drop entries.
 	s.SetApps([]DevApp{{Slug: "rss"}})
-	resp2, _ := http.Get("http://" + s.Addr() + "/v1/dev/apps")
+	resp2, err := http.Get("http://" + s.Addr() + "/v1/dev/apps")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp2.Body.Close()
 	var body2 struct{ Apps []DevApp }
 	_ = json.NewDecoder(resp2.Body).Decode(&body2)
@@ -120,11 +126,14 @@ func TestInvokeRoutesToInvoker(t *testing.T) {
 
 func TestInvokeMissingActionRejected(t *testing.T) {
 	s := startTestServer(t, &stubInvoker{})
-	resp, _ := http.Post(
+	resp, err := http.Post(
 		"http://"+s.Addr()+"/v1/dev/apps/rss/invoke",
 		"application/json",
 		strings.NewReader(`{}`),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 400 {
 		t.Errorf("expected 400, got %d", resp.StatusCode)
@@ -133,11 +142,14 @@ func TestInvokeMissingActionRejected(t *testing.T) {
 
 func TestInvokeInvokerError(t *testing.T) {
 	s := startTestServer(t, &stubInvoker{err: errors.New("boom")})
-	resp, _ := http.Post(
+	resp, err := http.Post(
 		"http://"+s.Addr()+"/v1/dev/apps/rss/invoke",
 		"application/json",
 		strings.NewReader(`{"action":"fetch"}`),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 400 {
 		t.Errorf("expected 400 on invoke error, got %d", resp.StatusCode)
@@ -146,11 +158,14 @@ func TestInvokeInvokerError(t *testing.T) {
 
 func TestInvokeWithoutInvoker503(t *testing.T) {
 	s := startTestServer(t, nil)
-	resp, _ := http.Post(
+	resp, err := http.Post(
 		"http://"+s.Addr()+"/v1/dev/apps/rss/invoke",
 		"application/json",
 		strings.NewReader(`{"action":"fetch"}`),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 503 {
 		t.Errorf("expected 503, got %d", resp.StatusCode)
@@ -171,7 +186,10 @@ func TestPushEventBufferRing(t *testing.T) {
 
 func TestManifest404OnUnknownSlug(t *testing.T) {
 	s := startTestServer(t, nil)
-	resp, _ := http.Get("http://" + s.Addr() + "/v1/dev/apps/missing/manifest")
+	resp, err := http.Get("http://" + s.Addr() + "/v1/dev/apps/missing/manifest")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 404 {
 		t.Errorf("expected 404, got %d", resp.StatusCode)
@@ -184,7 +202,10 @@ func TestManifestServesUpsertedApp(t *testing.T) {
 		Slug:     "rss",
 		Manifest: map[string]any{"name": "rss", "version": "0.1.0"},
 	})
-	resp, _ := http.Get("http://" + s.Addr() + "/v1/dev/apps/rss/manifest")
+	resp, err := http.Get("http://" + s.Addr() + "/v1/dev/apps/rss/manifest")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)

--- a/apps/cli/biu/internal/tools/interactive/worktree.go
+++ b/apps/cli/biu/internal/tools/interactive/worktree.go
@@ -70,14 +70,14 @@ type WorktreeState struct {
 	Branch    string
 }
 
-func (EnterWorktreeTool) Name() string { return "EnterWorktree" }
+func (*EnterWorktreeTool) Name() string { return "EnterWorktree" }
 
-func (EnterWorktreeTool) Description(_ map[string]any) string {
+func (*EnterWorktreeTool) Description(_ map[string]any) string {
 	return "Create a git worktree (new branch off HEAD) under " +
 		".biumind/worktrees/<name>, then switch the session into it."
 }
 
-func (EnterWorktreeTool) InputSchema() map[string]any {
+func (*EnterWorktreeTool) InputSchema() map[string]any {
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -89,10 +89,10 @@ func (EnterWorktreeTool) InputSchema() map[string]any {
 	}
 }
 
-func (EnterWorktreeTool) IsReadOnly(_ map[string]any) bool        { return false }
-func (EnterWorktreeTool) IsDestructive(_ map[string]any) bool     { return false }
-func (EnterWorktreeTool) IsConcurrencySafe(_ map[string]any) bool { return false }
-func (EnterWorktreeTool) InterruptBehavior() string               { return "block" }
+func (*EnterWorktreeTool) IsReadOnly(_ map[string]any) bool        { return false }
+func (*EnterWorktreeTool) IsDestructive(_ map[string]any) bool     { return false }
+func (*EnterWorktreeTool) IsConcurrencySafe(_ map[string]any) bool { return false }
+func (*EnterWorktreeTool) InterruptBehavior() string               { return "block" }
 
 func (e *EnterWorktreeTool) Call(ctx context.Context, input map[string]any, env *engine.ToolEnv) (*engine.ToolResultPayload, error) {
 	if e.Cwd == nil {

--- a/services/brain/cmd/memory-mcp/main.go
+++ b/services/brain/cmd/memory-mcp/main.go
@@ -67,7 +67,7 @@ type Config struct {
 	EmbedAPIKey   string `env:"EMBED_API_KEY" default:""`
 	EmbedBaseURL  string `env:"EMBED_BASE_URL" default:""`
 	EmbedModel    string `env:"EMBED_MODEL" default:"text-embedding-3-small"`
-	EmbedDims     int    `env:"EMBED_DIMS" default:"1536"`
+	EmbedDims     int    `env:"EMBED_DIMS" default:"1024"`
 
 	// Optional NATS — required only for wiki.ingest. Empty keeps the
 	// other 9 tools usable offline; wiki.ingest returns a clear

--- a/services/brain/internal/memory/consolidator/consolidator_test.go
+++ b/services/brain/internal/memory/consolidator/consolidator_test.go
@@ -73,7 +73,7 @@ func TestDedupe_MergesIdenticalContent(t *testing.T) {
 		_ = m
 	}
 	// Embed them so the dedupe pass has something to compare.
-	w := memworker.New(s, embed.NewStub(1536),
+	w := memworker.New(s, embed.NewStub(1024),
 		memworker.Config{Interval: time.Hour, Batch: 10})
 	if got := w.RunOnce(ctx); got != 2 {
 		t.Fatalf("worker: want 2 embedded, got %d", got)
@@ -122,7 +122,7 @@ func TestDedupe_DoesNotMergeDifferentContent(t *testing.T) {
 			t.Fatalf("create: %v", err)
 		}
 	}
-	w := memworker.New(s, embed.NewStub(1536),
+	w := memworker.New(s, embed.NewStub(1024),
 		memworker.Config{Interval: time.Hour, Batch: 10})
 	w.RunOnce(ctx)
 
@@ -153,7 +153,7 @@ func TestDedupe_DoesNotCrossProjects(t *testing.T) {
 			t.Fatalf("create: %v", err)
 		}
 	}
-	w := memworker.New(s, embed.NewStub(1536),
+	w := memworker.New(s, embed.NewStub(1024),
 		memworker.Config{Interval: time.Hour, Batch: 10})
 	w.RunOnce(ctx)
 

--- a/services/brain/internal/memory/worker/worker_test.go
+++ b/services/brain/internal/memory/worker/worker_test.go
@@ -76,11 +76,9 @@ func TestWorker_BackfillsEmbeddings(t *testing.T) {
 		}
 	}
 
-	// Stub embedder dim=64 — small dim so we don't bloat the test
-	// table and so the migration's vector(1536) column accepts the
-	// shorter literal via pgvector's text format only when dim matches.
-	// Since the column is fixed at 1536, we MUST use 1536 here.
-	w := New(s, embed.NewStub(1536), Config{
+	// The schema column is vector(1024) (bge-m3), so the stub embedder
+	// must emit 1024 dims to match.
+	w := New(s, embed.NewStub(1024), Config{
 		Interval: time.Hour, // never fires; we use RunOnce
 		Batch:    10,
 		Logger:   slog.New(slog.NewTextHandler(os.Stderr, nil)),
@@ -170,7 +168,7 @@ func TestWorker_HybridRecallBeatsLexicalAfterEmbedding(t *testing.T) {
 	create("uses Vim with vimwiki for editing notes")  // about 'vim'
 	create("Spanish translation prefs editor on side") // not about 'vim'
 
-	embedder := embed.NewStub(1536)
+	embedder := embed.NewStub(1024)
 	w := New(s, embedder, Config{Interval: time.Hour, Batch: 10})
 	if got := w.RunOnce(ctx); got < 2 {
 		t.Fatalf("expected 2 embedded, got %d", got)

--- a/services/brain/internal/note/store/revisions_test.go
+++ b/services/brain/internal/note/store/revisions_test.go
@@ -28,7 +28,7 @@ func updateNote(t *testing.T, h *storeHarness, uid, noteID uuid.UUID, title, con
 func backdateLastEditRevision(t *testing.T, h *storeHarness, noteID uuid.UUID, d time.Duration) {
 	t.Helper()
 	tag, err := h.pool.Exec(context.Background(), `
-		UPDATE brain.note_revisions SET created_at = now() - $2
+		UPDATE brain.note_revisions SET created_at = now() - $2::interval
 		WHERE id = (
 			SELECT id FROM brain.note_revisions
 			WHERE note_id = $1 AND change_type = 'edit'

--- a/services/identity/internal/admin/admin_test.go
+++ b/services/identity/internal/admin/admin_test.go
@@ -260,7 +260,10 @@ func TestAdmin_SetPlan_RejectsInvalidPlan(t *testing.T) {
 		ts.URL+"/v1/admin/users/u1/plan", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+tok)
 	req.Header.Set("Content-Type", "application/json")
-	resp, _ := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 400 {
 		t.Errorf("status: %d, want 400", resp.StatusCode)

--- a/services/realtime/internal/hub/hub.go
+++ b/services/realtime/internal/hub/hub.go
@@ -137,7 +137,12 @@ func (h *Hub) Publish(e ledger.Event) (delivered, dropped int) {
 	h.mu.RUnlock()
 
 	for _, c := range targets {
+		// Hold closeMu so Close() cannot close c.out between the closed
+		// check and the send. The send stays non-blocking, so the lock
+		// is never held while waiting on a consumer.
+		c.closeMu.Lock()
 		if c.closed.Load() {
+			c.closeMu.Unlock()
 			continue
 		}
 		select {
@@ -148,6 +153,7 @@ func (h *Hub) Publish(e ledger.Event) (delivered, dropped int) {
 			dropped++
 			go c.Close()
 		}
+		c.closeMu.Unlock()
 	}
 	return
 }


### PR DESCRIPTION
Go workflow 6 个 test job 失败的修复（全部是既有问题，调查报告逐条核对过基线 run，与 Dependabot 升级无关）：

1. **identity** `admin_test.go:263`：`resp, _ := http.DefaultClient.Do(req)` 未查 err（vet httpresponse）→ 加 `t.Fatal(err)`
2. **cli/biu**：11 处测试同款 httpresponse；`internal/tools/interactive/worktree.go` 7 个方法值接收者拷贝含 `sync.Mutex` 的结构（copylocks）→ 改指针接收者（`Call` 本就是指针接收者，接口兼容）
3. **matrix 残留**：`go.yml`/`security.yml` 里的 `services/hub` 目录在仓库历史中从未存在 → 改为实际存在且未覆盖的 `services/model-relay`
4. **realtime data race**（真 bug）：`hub.go` Publish 在 `closed.Load()` 检查与向 `c.out` 发送之间无同步，Close() 并发 close channel → send-on-closed panic 风险。发送路径持 `c.closeMu` 与 Close 互斥；发送保持 non-blocking，`go c.Close()` 异步触发不持锁等待。`go test -race -count=3` 通过
5. **app_center**：CI 只对 brain 应用迁移，app_center 的 4 个 dispatcher 测试因 `app_center.installations` 不存在失败 → go.yml 增加 app_center schema 应用步骤（复用 brain 步骤的 sed 剥 goose 注解方式；baseline 迁移自建 extension/schema）
6. **brain**：schema 列是 `vector(1024)` 但 5 处测试用 `embed.NewStub(1536)` → 全改 1024（`cmd/memory-mcp` 的 `EMBED_DIMS default:"1536"` 同款隐患一并修）；`revisions_test.go` 的 `now() - $2` 缺 cast 被 PG 推断成 interval → 加 `::interval`（与生产代码 `chat/store.go` 模式一致）

验证（本地 GOTOOLCHAIN=auto）：identity/cli/realtime/brain 的 vet+build 干净，identity admin、cli bridge/devserver/interactive、realtime -race 测试全过；DB 依赖测试本地无 Postgres，由 CI 验证。
