### PR TITLE
fix(ci): apply all service schemas in Go tests; migrate to onReorderItem

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -74,8 +74,7 @@ jobs:
           cache-dependency-path: |
             **/go.sum
 
-      - name: Apply brain.* schema (modules that need it)
-        if: matrix.module == 'services/brain'
+      - name: Apply service schemas
         env:
           PGHOST: localhost
           PGPORT: 5432
@@ -91,32 +90,12 @@ jobs:
           CREATE EXTENSION IF NOT EXISTS pg_trgm;
           CREATE SCHEMA IF NOT EXISTS brain;
           SQL
-          # Apply the goose-marked migrations in order; we strip the
-          # +goose pragmas with sed so plain psql executes them.
-          for f in services/brain/migrations/*.sql; do
-            echo "-- applying $f --"
-            sed -e '/^-- +goose Down/,$d' \
-                -e '/^-- +goose Up/d' \
-                -e '/^-- +goose StatementBegin/d' \
-                -e '/^-- +goose StatementEnd/d' \
-                "$f" | psql -v ON_ERROR_STOP=1
-          done
-
-      - name: Apply app_center.* schema (modules that need it)
-        if: matrix.module == 'services/app_center'
-        env:
-          PGHOST: localhost
-          PGPORT: 5432
-          PGUSER: biumind
-          PGPASSWORD: biumind_ci
-          PGDATABASE: biu_core
-        run: |
-          # Extensions + schemas are created by the baseline migration
-          # itself; only the pgvector image's `vector` extension must
-          # be loadable.
-          # Apply the goose-marked migrations in order; we strip the
-          # +goose pragmas with sed so plain psql executes them.
-          for f in services/app_center/migrations/*.sql; do
+          # Tests reach across service schemas (e.g. app_center's
+          # installer touches runtime.skills), so apply every module's
+          # migrations, not just the matrix module's own. Baselines
+          # create their own schemas and are IF NOT EXISTS-idempotent.
+          # Strip the +goose pragmas with sed so plain psql executes them.
+          for f in services/*/migrations/*.sql; do
             echo "-- applying $f --"
             sed -e '/^-- +goose Down/,$d' \
                 -e '/^-- +goose Up/d' \

--- a/.github/workflows/release-biu-snapshot.yml
+++ b/.github/workflows/release-biu-snapshot.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version-file: apps/cli/biu/go.mod
+          go-version-file: go.work
           cache: true
           cache-dependency-path: apps/cli/biu/go.sum
 

--- a/.github/workflows/release-biu.yml
+++ b/.github/workflows/release-biu.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version-file: apps/cli/biu/go.mod
+          go-version-file: go.work
           cache: true
           cache-dependency-path: apps/cli/biu/go.sum
 

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Go (biu CLI build)
         uses: actions/setup-go@v7
         with:
-          go-version-file: apps/cli/biu/go.mod
+          go-version-file: go.work
 
       - name: Build biu CLI (app sidecar + 4-platform standalone)
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/release-sdks.yml
+++ b/.github/workflows/release-sdks.yml
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v7
         with:
-          go-version-file: sdks/go/go.mod
+          go-version-file: go.work
 
       - name: Verify build + tests pass
         working-directory: sdks/go

--- a/apps/client/lib/data/api/_http_helpers.dart
+++ b/apps/client/lib/data/api/_http_helpers.dart
@@ -107,7 +107,7 @@ Future<Map<String, dynamic>> apiRequest({
     final headers = <String, String>{
       'accept': 'application/json',
       if (token != null && token.isNotEmpty) 'authorization': 'Bearer $token',
-      if (extraHeaders != null) ...extraHeaders,
+      ...?extraHeaders,
     };
     final encoded = body == null ? null : jsonEncode(body);
     if (encoded != null) headers['content-type'] = 'application/json';
@@ -175,7 +175,7 @@ Future<Uint8List> binaryRequest({
     final headers = <String, String>{
       'accept': accept,
       if (token != null && token.isNotEmpty) 'authorization': 'Bearer $token',
-      if (extraHeaders != null) ...extraHeaders,
+      ...?extraHeaders,
     };
     final encoded = body == null ? null : jsonEncode(body);
     if (encoded != null) headers['content-type'] = 'application/json';

--- a/apps/client/lib/features/apps/presentation/sidebar_customize_page.dart
+++ b/apps/client/lib/features/apps/presentation/sidebar_customize_page.dart
@@ -349,8 +349,7 @@ class _Editor extends StatelessWidget {
           ),
         );
       },
-      onReorder: (oldIdx, newIdx) {
-        if (newIdx > oldIdx) newIdx -= 1;
+      onReorderItem: (oldIdx, newIdx) {
         final reorderedIds = [...orderedIds];
         final moved = reorderedIds.removeAt(oldIdx);
         reorderedIds.insert(newIdx, moved);
@@ -458,10 +457,8 @@ class _Editor extends StatelessWidget {
           ),
         );
       },
-      onReorder: (oldIdx, newIdx) {
-        // ReorderableListView convention: when moving down, newIndex
-        // is the post-removal index (one past target). Normalise.
-        if (newIdx > oldIdx) newIdx -= 1;
+      onReorderItem: (oldIdx, newIdx) {
+        // onReorderItem 的 newIndex 已完成移除项修正, 无需手动 -1。
         final reordered = [...appRows];
         final moved = reordered.removeAt(oldIdx);
         reordered.insert(newIdx, moved);

--- a/apps/client/lib/features/code/application/projects_controller.dart
+++ b/apps/client/lib/features/code/application/projects_controller.dart
@@ -54,14 +54,13 @@ class CodeProjectsController extends StateNotifier<List<CodeProject>> {
   }
 
   /// 拖拽重排可见(非隐藏)项目。oldIndex/newIndex 为 railProjects 列表内的下标
-  /// (ReorderableList 约定:newIndex 在移除前计)。隐藏项目保持相对序排到末尾,
+  /// (onReorderItem 约定:newIndex 已完成移除项修正)。隐藏项目保持相对序排到末尾,
   /// 整体重写 sortIndex 持久化。
   Future<void> reorderVisible(int oldIndex, int newIndex) async {
     final visible = state.where((p) => !p.hiddenFromRail).toList();
     if (oldIndex < 0 || oldIndex >= visible.length) return;
-    var target = newIndex > oldIndex ? newIndex - 1 : newIndex;
     final moved = visible.removeAt(oldIndex);
-    visible.insert(target.clamp(0, visible.length), moved);
+    visible.insert(newIndex.clamp(0, visible.length), moved);
     final hidden = state.where((p) => p.hiddenFromRail).toList();
     final full = [...visible, ...hidden];
     await _dao.reorder(full.map((p) => p.id).toList());

--- a/apps/client/lib/features/code/presentation/project_rail.dart
+++ b/apps/client/lib/features/code/presentation/project_rail.dart
@@ -44,7 +44,7 @@ class ProjectRail extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(vertical: 4),
               buildDefaultDragHandles: false,
               itemCount: projects.length,
-              onReorder: (oldIndex, newIndex) {
+              onReorderItem: (oldIndex, newIndex) {
                 ref
                     .read(codeProjectsControllerProvider.notifier)
                     .reorderVisible(oldIndex, newIndex);

--- a/apps/client/lib/features/wiki/presentation/wiki_page.dart
+++ b/apps/client/lib/features/wiki/presentation/wiki_page.dart
@@ -472,17 +472,23 @@ class _LeftPaneState extends ConsumerState<_LeftPane> {
                   itemBuilder: (_, i) {
                     final p = s.pages[i];
                     final selected = p.id == s.activePage?.id;
-                    return ListTile(
-                      title: Text(p.title.isEmpty ? '(untitled)' : p.title),
-                      trailing: p.pendingCreate
-                          ? const Icon(Icons.cloud_upload_outlined, size: 16)
-                          : null,
-                      selected: selected,
-                      onTap: () {
-                        ref.read(wikiControllerProvider.notifier).selectPage(p);
-                        // 手机 bottom sheet 形态选中后关 sheet（桌面为 null）。
-                        widget.onPageSelected?.call();
-                      },
+                    // 包一层透明 Material：左栏容器是 ColoredBox 背景，
+                    // ListTile 的选中底色/水波纹画在最近 Material 祖先上，
+                    // 新版 Flutter 对此有断言（背景会被 ColoredBox 盖住）。
+                    return Material(
+                      type: MaterialType.transparency,
+                      child: ListTile(
+                        title: Text(p.title.isEmpty ? '(untitled)' : p.title),
+                        trailing: p.pendingCreate
+                            ? const Icon(Icons.cloud_upload_outlined, size: 16)
+                            : null,
+                        selected: selected,
+                        onTap: () {
+                          ref.read(wikiControllerProvider.notifier).selectPage(p);
+                          // 手机 bottom sheet 形态选中后关 sheet（桌面为 null）。
+                          widget.onPageSelected?.call();
+                        },
+                      ),
                     );
                   },
                 ),

--- a/apps/client/lib/services/settings_repo.dart
+++ b/apps/client/lib/services/settings_repo.dart
@@ -379,12 +379,11 @@ class SecureSettingsRepo implements SettingsRepo {
   /// 持久化异常(写后读校验失败)钩子 — 留给后续遥测接入;默认 null 时只 print。
   static void Function(String message)? onPersistWarning;
 
-  /// Android 用 EncryptedSharedPreferences(AES/GCM, 替代部分 ROM 上会炸的
-  /// legacy RSA/ECB Keystore) + resetOnError 自愈;iOS/macOS 用
+  /// Android 用 resetOnError 自愈(encryptedSharedPreferences 在 v10 已废弃,
+  /// 首访自动迁移到 custom ciphers);iOS/macOS 用
   /// first_unlock_this_device(不随备份迁移, 重启后首次解锁即可读)。
   static FlutterSecureStorage _defaultStorage() => const FlutterSecureStorage(
     aOptions: AndroidOptions(
-      encryptedSharedPreferences: true,
       resetOnError: true,
     ),
     iOptions: IOSOptions(

--- a/apps/client/test/features/code/projects_controller_test.dart
+++ b/apps/client/test/features/code/projects_controller_test.dart
@@ -80,8 +80,8 @@ void main() {
     await ctrl.addProjectByPath('/repos/c'); // -2, front
     // current visible order: c, b, a
     expect(ctrl.state.map((p) => p.path), ['/repos/c', '/repos/b', '/repos/a']);
-    // move c (index 0) to the end (newIndex 3 per ReorderableList convention)
-    await ctrl.reorderVisible(0, 3);
+    // move c (index 0) to the end (newIndex 2 per onReorderItem convention)
+    await ctrl.reorderVisible(0, 2);
     expect(ctrl.state.map((p) => p.path), ['/repos/b', '/repos/a', '/repos/c']);
     // persisted: reload from DAO matches
     final reloaded = await CodeProjectsDao(db).loadAll();

--- a/services/model-relay/internal/health/supervisor_test.go
+++ b/services/model-relay/internal/health/supervisor_test.go
@@ -40,6 +40,15 @@ func TestSupervisorAutoDisableThenRecover(t *testing.T) {
 		}
 	}
 
+	// R4-B: 翻到 auto_disabled 时 RecordFailureKind 会按指数退避写
+	// cooldown_until（第一档 30s）。本测试关心 sweep→probe→恢复链路，
+	// 把 cooldown 拨到过去，让下一个 sweep tick 就能捞起这条记录。
+	if _, err := fx.pool.Exec(ctx,
+		"UPDATE model_relay.channels SET cooldown_until = now() - interval '1 second' WHERE id = $1",
+		fx.channel.ID); err != nil {
+		t.Fatalf("reset cooldown_until: %v", err)
+	}
+
 	// Wait for sweep to run — it polls every 50ms; 1s is plenty.
 	deadline := time.Now().Add(2 * time.Second)
 	var got *registry.Channel

--- a/services/model-relay/internal/router/e2e_integration_test.go
+++ b/services/model-relay/internal/router/e2e_integration_test.go
@@ -171,6 +171,15 @@ func TestE2E_ChannelAutoDisableThenRecover(t *testing.T) {
 		_, _, _ = sup.RecordFailure(ctx, chA.ID, errors.New("e2e simulated 500"))
 	}
 
+	// R4-B: 翻到 auto_disabled 时会按指数退避写 cooldown_until（第一档
+	// 30s）。本测试关心「上游恢复 → sweep 捞回」链路，把 cooldown 拨到
+	// 过去，让 100ms 的 sweep 下一轮就能重试 chA。
+	if _, err := pool.Exec(ctx,
+		"UPDATE model_relay.channels SET cooldown_until = now() - interval '1 second' WHERE id = $1",
+		chA.ID); err != nil {
+		t.Fatalf("reset cooldown_until: %v", err)
+	}
+
 	// Wait for the NOTIFY → cache invalidation to land.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
第二轮 CI 修复（基于 11:36 批次的失败日志）：

**Go**：schema 步骤从「按 matrix 模块条件应用」改为「无条件应用所有 services/*/migrations」。原因：测试跨 schema 访问——app_center 的 installer 测到 `runtime.skills`、identity 需要 `billing.*`、model-relay 需要 `model_relay.*`。各 baseline 自建 schema 且幂等，无跨 schema FK，顺序无关。

**Flutter analyze 剩余 6 个 info**（CI 的 stable SDK 比本地 3.41.9 的 analyzer 新才暴露）：
- `_http_helpers.dart` ×2：null-aware spread `...?extraHeaders`
- `onReorder` → `onReorderItem` ×3：新回调的 newIndex 已完成移除项修正，删掉两处 handler 和 `reorderVisible` 里的手动 `-1`（签名同为 `ReorderCallback`，已查官方 API 文档确认）；对应测试按新约定改 `(0,3)→(0,2)`
- `settings_repo.dart`：删 deprecated 的 `encryptedSharedPreferences`（v10 首访自动迁移到 custom ciphers）

注意：`onReorderItem` 需要 Flutter ≥3.44（stable channel），与 webview_flutter_android 4.13 要求的 Dart ^3.12 一致——本地 3.41.9 已无法编译 main，升级 Flutter 是必须项。

验证：本地 27 个相关测试全过（controller/settings 不依赖新 SDK）；onReorderItem 的编译正确性只能由 CI 的 3.44 验证。
