### PR TITLE
ci(release): fix release-images workflow error and client snapshot path

### DIFF
--- a/.github/workflows/release-client-snapshot.yml
+++ b/.github/workflows/release-client-snapshot.yml
@@ -79,7 +79,7 @@ jobs:
       # assets/editor/ and web/editor/); build it or the native editor
       # region white-screens (index.html / chunks 404).
       - name: Build editor bundle (Milkdown)
-        working-directory: editor-web
+        working-directory: apps/client/editor-web
         run: |
           npm ci
           npm run build
@@ -134,7 +134,7 @@ jobs:
           cache: true
 
       - name: Build editor bundle (Milkdown)
-        working-directory: editor-web
+        working-directory: apps/client/editor-web
         run: |
           npm ci
           npm run build

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -19,7 +19,7 @@
 #   * `service-v*` tag (e.g. `service-v0.3.0`) — full release: builds
 #     all 10 service images so they share a version tag and digest
 #     table.
-#   * `<svc>-v*` tag (e.g. `hub-v0.3.1`, `brain-v0.4.0`) — single-
+#   * `<svc>-v*` tag (e.g. `model-relay-v0.3.1`, `brain-v0.4.0`) — single-
 #     service hotfix release; only the matching image is built.
 #   * Manual workflow_dispatch with a `service` input — push just one.
 #
@@ -47,15 +47,12 @@ on:
       # Per-service hotfix tags. Each prefix MUST match a matrix row
       # below; the filter step extracts the service name from the tag.
       - "identity-v*"
-      - "hub-v*"
+      - "model-relay-v*"
       - "brain-v*"
-      - "sandbox-v*"
       - "runtime-v*"
       - "realtime-v*"
-      - "channels-v*"
       - "app_center-v*"
       - "authz-v*"
-      - "deploy-v*"
   workflow_dispatch:
     inputs:
       service:
@@ -65,15 +62,12 @@ on:
         options:
           - ""
           - identity
-          - hub
+          - model-relay
           - brain
-          - sandbox
           - runtime
           - realtime
-          - channels
           - app_center
           - authz
-          - deploy
       severity:
         description: "Trivy fail threshold"
         required: false
@@ -93,20 +87,24 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      # secrets 不能直接出现在 if: 里 — 先在 job env 里折算成布尔字符串。
+      HAVE_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+      HAVE_ALIYUN_PASSWORD: ${{ secrets.ALIYUN_PASSWORD != '' }}
     strategy:
       fail-fast: false
       matrix:
         service:
+          # 只列仓库里实际有 Dockerfile 的服务（hub/sandbox/channels/
+          # deploy 在公开仓库不存在或无 Dockerfile；hub 的公开名是
+          # model-relay）。
           - identity
-          - hub
+          - model-relay
           - brain
-          - sandbox
           - runtime
           - realtime
-          - channels
           - app_center
           - authz
-          - deploy
 
     steps:
       - uses: actions/checkout@v4
@@ -158,7 +156,7 @@ jobs:
       # Optional registries — skipped unless both namespace var and
       # credential secret are configured in repo settings.
       - name: Log in to Docker Hub
-        if: steps.filt.outputs.skip == 'false' && vars.DOCKERHUB_NAMESPACE != '' && secrets.DOCKERHUB_TOKEN != ''
+        if: steps.filt.outputs.skip == 'false' && vars.DOCKERHUB_NAMESPACE != '' && env.HAVE_DOCKERHUB_TOKEN == 'true'
         uses: docker/login-action@v3
         with:
           registry: docker.io
@@ -166,7 +164,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to Aliyun ACR
-        if: steps.filt.outputs.skip == 'false' && vars.ALIYUN_REGISTRY != '' && secrets.ALIYUN_PASSWORD != ''
+        if: steps.filt.outputs.skip == 'false' && vars.ALIYUN_REGISTRY != '' && env.HAVE_ALIYUN_PASSWORD == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ vars.ALIYUN_REGISTRY }}

--- a/go.work.sum
+++ b/go.work.sum
@@ -738,6 +738,7 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
+github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/firefart/nonamedreturns v1.0.6/go.mod h1:R8NisJnSIpvPWheCq0mNRXJok6D8h7fagJTF8EMEwCo=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -1539,6 +1540,7 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0/go.mod h1:
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0/go.mod h1:69uWxva0WgAA/4bu2Yy70SLDBwZXuQ6PbBpbsa5iZrQ=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
 go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzoxm/dooo=
 go.opentelemetry.io/otel v1.21.0/go.mod h1:QZzNPQPm1zLX4gZK4cMi+71eaorMSGT3A4znnUvNNEo=


### PR DESCRIPTION
**release-images.yml（每次 main push 都 workflow 级失败，零 job）**：
- `if:` 里直接引用 `secrets.DOCKERHUB_TOKEN` / `secrets.ALIYUN_PASSWORD` —— GitHub 不允许 secrets 出现在条件表达式（与 #31 修的 release-client/perf 同类）。改为 job 级 env 布尔折算（`HAVE_*: ${{ secrets.X != '' }}`），条件里用 `env.HAVE_* == 'true'`，不把 secret 本体放进 env。
- matrix/tag 模式/dispatch 选项里的 `hub`、`sandbox`、`channels`、`deploy` 在公开仓库没有 Dockerfile（hub 的公开名是 model-relay）——上一批 run 里这 4 个 build job 全部 `lstat services/<svc>: no such file or directory`。matrix 只保留有 Dockerfile 的 7 个服务（identity、model-relay、brain、runtime、realtime、app_center、authz）。注意 `aigc` 也有 Dockerfile 但不在原 matrix 里，未擅自加入。

**release-client-snapshot.yml（Client snapshot 的 apk/dmg job 失败）**：editor bundle 步骤 `working-directory: editor-web` 指向仓库根（不存在），改为 `apps/client/editor-web`。
