### PR TITLE
fix(biu): reproducible builds (CommitDate) for stable brew checksums

### DIFF
--- a/apps/cli/biu/.goreleaser.yml
+++ b/apps/cli/biu/.goreleaser.yml
@@ -55,7 +55,12 @@ builds:
       - -s -w
       - -X main.version={{.Version}}
       - -X main.commit={{.ShortCommit}}
-      - -X main.buildDate={{.Date}}
+      # CommitDate (not .Date) for reproducible builds. .Date is the
+      # wall-clock build time, changing every CI run → different binary
+      # → different sha256 → brew formula/asset desync (the v0.1.0
+      # checksum-mismatch bug). CommitDate is fixed per commit, so
+      # re-runs at the same commit are bit-identical.
+      - -X main.buildDate={{.CommitDate}}
 
 archives:
   - id: biu


### PR DESCRIPTION
## Problem

`brew install biumind/tap/biu` failed with a checksum mismatch on v0.1.0:

```
Formula reports:   d536…e9af5
Downloaded sha256: 4815…4103
```

The formula and the published assets were generated by **different** goreleaser runs and drifted apart.

## Root cause

`buildDate` used the `{{.Date}}` ldflag = wall-clock build time. Every CI run produced a **different binary → different sha256**. A re-run of the release overwrote the assets (new checksums) but the already-merged brew formula kept the old sha256 → mismatch.

## Fix

`{{.Date}}` → `{{.CommitDate}}`. Commit date is fixed per commit, so re-runs at the same commit are **bit-identical** → sha256 never drifts → formula stays valid.

`buildDate` is cosmetic only (`biu version` display + install info; defaults to `"unknown"`), so zero functional risk. Field verified to exist in goreleaser v2.

## Related

- `draft: false` (required for brew — draft assets 404 to unauthenticated downloads) already landed on main via #49.
- v0.1.0's stale formula was hand-patched to match the published assets (one-off; future releases regenerate fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)